### PR TITLE
Modernization-metadata for aio-tests

### DIFF
--- a/aio-tests/modernization-metadata/2025-07-02T17-50-23.json
+++ b/aio-tests/modernization-metadata/2025-07-02T17-50-23.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "aio-tests",
+  "pluginRepository": "https://github.com/jenkinsci/aio-tests-plugin.git",
+  "pluginVersion": "1.15",
+  "rpuBaseline": "2.492",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/aio-tests-plugin/pull/17",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 7,
+  "deletions": 15,
+  "changedFiles": 1,
+  "key": "2025-07-02T17-50-23.json",
+  "path": "metadata-plugin-modernizer/aio-tests/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `aio-tests` at `2025-07-02T17:50:24.596143957Z[UTC]`
PR: https://github.com/jenkinsci/aio-tests-plugin/pull/17