### PR TITLE
Modernization-metadata for apprenda

### DIFF
--- a/apprenda/modernization-metadata/2025-07-02T18-42-26.json
+++ b/apprenda/modernization-metadata/2025-07-02T18-42-26.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "apprenda",
+  "pluginRepository": "https://github.com/jenkinsci/apprenda-plugin.git",
+  "pluginVersion": "2.2.0",
+  "rpuBaseline": "2.492",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/apprenda-plugin/pull/2",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 19,
+  "deletions": 17,
+  "changedFiles": 2,
+  "key": "2025-07-02T18-42-26.json",
+  "path": "metadata-plugin-modernizer/apprenda/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `apprenda` at `2025-07-02T18:42:27.863264729Z[UTC]`
PR: https://github.com/jenkinsci/apprenda-plugin/pull/2