### PR TITLE
Modernization-metadata for ascentialtest-cmd-line

### DIFF
--- a/ascentialtest-cmd-line/modernization-metadata/2025-07-02T19-02-14.json
+++ b/ascentialtest-cmd-line/modernization-metadata/2025-07-02T19-02-14.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "ascentialtest-cmd-line",
+  "pluginRepository": "https://github.com/jenkinsci/ascentialtest-cmd-line-plugin.git",
+  "pluginVersion": "1.1",
+  "rpuBaseline": "2.492",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/ascentialtest-cmd-line-plugin/pull/9",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 13,
+  "deletions": 13,
+  "changedFiles": 2,
+  "key": "2025-07-02T19-02-14.json",
+  "path": "metadata-plugin-modernizer/ascentialtest-cmd-line/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `ascentialtest-cmd-line` at `2025-07-02T19:02:15.574043722Z[UTC]`
PR: https://github.com/jenkinsci/ascentialtest-cmd-line-plugin/pull/9