### PR TITLE
Modernization-metadata for aws-lambda-cloud

### DIFF
--- a/aws-lambda-cloud/modernization-metadata/2025-07-02T19-49-48.json
+++ b/aws-lambda-cloud/modernization-metadata/2025-07-02T19-49-48.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "aws-lambda-cloud",
+  "pluginRepository": "https://github.com/jenkinsci/aws-lambda-cloud-plugin.git",
+  "pluginVersion": "0.4",
+  "rpuBaseline": "2.492",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/aws-lambda-cloud-plugin/pull/10",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 18,
+  "deletions": 15,
+  "changedFiles": 2,
+  "key": "2025-07-02T19-49-48.json",
+  "path": "metadata-plugin-modernizer/aws-lambda-cloud/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `aws-lambda-cloud` at `2025-07-02T19:49:49.373667989Z[UTC]`
PR: https://github.com/jenkinsci/aws-lambda-cloud-plugin/pull/10