### PR TITLE
Modernization-metadata for bitbucket-pullrequest-builder

### DIFF
--- a/bitbucket-pullrequest-builder/modernization-metadata/2025-07-02T20-33-11.json
+++ b/bitbucket-pullrequest-builder/modernization-metadata/2025-07-02T20-33-11.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "bitbucket-pullrequest-builder",
+  "pluginRepository": "https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin.git",
+  "pluginVersion": "1.5.0",
+  "rpuBaseline": "2.479",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin/pull/25",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 6,
+  "deletions": 20,
+  "changedFiles": 2,
+  "key": "2025-07-02T20-33-11.json",
+  "path": "metadata-plugin-modernizer/bitbucket-pullrequest-builder/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `bitbucket-pullrequest-builder` at `2025-07-02T20:33:12.529673592Z[UTC]`
PR: https://github.com/jenkinsci/bitbucket-pullrequest-builder-plugin/pull/25