### PR TITLE
Modernization-metadata for build-executors-filter-offline

### DIFF
--- a/build-executors-filter-offline/modernization-metadata/2025-07-02T20-46-28.json
+++ b/build-executors-filter-offline/modernization-metadata/2025-07-02T20-46-28.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "build-executors-filter-offline",
+  "pluginRepository": "https://github.com/jenkinsci/build-executors-filter-offline-plugin.git",
+  "pluginVersion": "1.1",
+  "rpuBaseline": "2.492",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/build-executors-filter-offline-plugin/pull/5",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 11,
+  "deletions": 14,
+  "changedFiles": 2,
+  "key": "2025-07-02T20-46-28.json",
+  "path": "metadata-plugin-modernizer/build-executors-filter-offline/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `build-executors-filter-offline` at `2025-07-02T20:46:30.162222499Z[UTC]`
PR: https://github.com/jenkinsci/build-executors-filter-offline-plugin/pull/5