### PR TITLE
Modernization-metadata for ca-mat-performance-benchmarking-by-broadcom

### DIFF
--- a/ca-mat-performance-benchmarking-by-broadcom/modernization-metadata/2025-06-13T14-12-37.json
+++ b/ca-mat-performance-benchmarking-by-broadcom/modernization-metadata/2025-06-13T14-12-37.json
@@ -1,0 +1,14 @@
+{
+  "pluginName": "ca-mat-performance-benchmarking-by-broadcom",
+  "pluginRepository": "https://github.com/jenkinsci/ca-mat-performance-benchmarking-by-broadcom-plugin.git",
+  "pluginVersion": "1.7",
+  "rpuBaseline": "2.204",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "key": "2025-06-13T14-12-37.json",
+  "path": "metadata-plugin-modernizer/ca-mat-performance-benchmarking-by-broadcom/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `ca-mat-performance-benchmarking-by-broadcom` at `2025-06-13T14:12:38.523594117Z[UTC]`