### PR TITLE
Modernization-metadata for aws-sqs-trigger

### DIFF
--- a/aws-sqs-trigger/modernization-metadata/2025-07-02T20-02-44.json
+++ b/aws-sqs-trigger/modernization-metadata/2025-07-02T20-02-44.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "aws-sqs-trigger",
+  "pluginRepository": "https://github.com/jenkinsci/aws-sqs-trigger-plugin.git",
+  "pluginVersion": "1.2",
+  "rpuBaseline": "2.263",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "fail",
+  "pullRequestUrl": "",
+  "pullRequestStatus": "",
+  "dryRun": false,
+  "additions": 0,
+  "deletions": 0,
+  "changedFiles": 0,
+  "key": "2025-07-02T20-02-44.json",
+  "path": "metadata-plugin-modernizer/aws-sqs-trigger/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `aws-sqs-trigger` at `2025-07-02T20:02:45.768958429Z[UTC]`
PR: null