### PR TITLE
Modernization-metadata for syslog-logger

### DIFF
--- a/syslog-logger/modernization-metadata/2025-07-07T08-01-28.json
+++ b/syslog-logger/modernization-metadata/2025-07-07T08-01-28.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "syslog-logger",
+  "pluginRepository": "https://github.com/jenkinsci/syslog-logger-plugin.git",
+  "pluginVersion": "1.0.5",
+  "rpuBaseline": "2.479",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/syslog-logger-plugin/pull/2",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 10,
+  "deletions": 17,
+  "changedFiles": 2,
+  "key": "2025-07-07T08-01-28.json",
+  "path": "metadata-plugin-modernizer/syslog-logger/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `syslog-logger` at `2025-07-07T08:01:30.341428763Z[UTC]`
PR: https://github.com/jenkinsci/syslog-logger-plugin/pull/2