### PR TITLE
Modernization-metadata for compuware-topaz-for-total-test

### DIFF
--- a/compuware-topaz-for-total-test/modernization-metadata/2025-07-07T08-28-09.json
+++ b/compuware-topaz-for-total-test/modernization-metadata/2025-07-07T08-28-09.json
@@ -1,0 +1,21 @@
+{
+  "pluginName": "compuware-topaz-for-total-test",
+  "pluginRepository": "https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin.git",
+  "pluginVersion": "2.4.16",
+  "rpuBaseline": "2.492",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin/pull/69",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 6,
+  "deletions": 9,
+  "changedFiles": 2,
+  "key": "2025-07-07T08-28-09.json",
+  "path": "metadata-plugin-modernizer/compuware-topaz-for-total-test/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `compuware-topaz-for-total-test` at `2025-07-07T08:28:10.795371997Z[UTC]`
PR: https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin/pull/69