### PR TITLE
Modernization-metadata for compuware-topaz-for-total-test

### DIFF
--- a/compuware-topaz-for-total-test/modernization-metadata/2025-07-07T08-34-55.json
+++ b/compuware-topaz-for-total-test/modernization-metadata/2025-07-07T08-34-55.json
@@ -1,0 +1,22 @@
+{
+  "pluginName": "compuware-topaz-for-total-test",
+  "pluginRepository": "https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin.git",
+  "pluginVersion": "2.4.16",
+  "rpuBaseline": "2.462",
+  "migrationName": "Setup dependabot",
+  "migrationDescription": "Setup dependabot for the Jenkins plugin if it doesn\u0027t exist.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupDependabot",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin/pull/71",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 10,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-07-07T08-34-55.json",
+  "path": "metadata-plugin-modernizer/compuware-topaz-for-total-test/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `compuware-topaz-for-total-test` at `2025-07-07T08:34:57.274671557Z[UTC]`
PR: https://github.com/jenkinsci/compuware-topaz-for-total-test-plugin/pull/71