### PR TITLE
Modernization-metadata for wavefront

### DIFF
--- a/wavefront/modernization-metadata/2025-07-22T08-41-44.json
+++ b/wavefront/modernization-metadata/2025-07-22T08-41-44.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "wavefront",
+  "pluginRepository": "https://github.com/jenkinsci/wavefront-plugin.git",
+  "pluginVersion": "1.1.4",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.361",
+  "effectiveBaseline": "2.361",
+  "jenkinsVersion": "2.361.4",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/wavefront-plugin/pull/2",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-07-22T08-41-44.json",
+  "path": "metadata-plugin-modernizer/wavefront/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `wavefront` at `2025-07-22T08:41:45.717834206Z[UTC]`
PR: https://github.com/jenkinsci/wavefront-plugin/pull/2