### PR TITLE
Modernization-metadata for vectorcast-coverage

### DIFF
--- a/vectorcast-coverage/modernization-metadata/2025-07-22T10-41-07.json
+++ b/vectorcast-coverage/modernization-metadata/2025-07-22T10-41-07.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "vectorcast-coverage",
+  "pluginRepository": "https://github.com/jenkinsci/vectorcast-coverage-plugin.git",
+  "pluginVersion": "0.22",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.361",
+  "effectiveBaseline": "2.361",
+  "jenkinsVersion": "2.361",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/vectorcast-coverage-plugin/pull/19",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-07-22T10-41-07.json",
+  "path": "metadata-plugin-modernizer/vectorcast-coverage/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `vectorcast-coverage` at `2025-07-22T10:41:09.267565565Z[UTC]`
PR: https://github.com/jenkinsci/vectorcast-coverage-plugin/pull/19