### PR TITLE
Modernization-metadata for loadfocus-loadtest

### DIFF
--- a/loadfocus-loadtest/modernization-metadata/2025-07-22T16-34-14.json
+++ b/loadfocus-loadtest/modernization-metadata/2025-07-22T16-34-14.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "loadfocus-loadtest",
+  "pluginRepository": "https://github.com/jenkinsci/loadfocus-loadtest-plugin.git",
+  "pluginVersion": "1.1.5",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.249",
+  "effectiveBaseline": "2.249",
+  "jenkinsVersion": "2.249.3",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/loadfocus-loadtest-plugin/pull/26",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-07-22T16-34-14.json",
+  "path": "metadata-plugin-modernizer/loadfocus-loadtest/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `loadfocus-loadtest` at `2025-07-22T16:34:16.269624633Z[UTC]`
PR: https://github.com/jenkinsci/loadfocus-loadtest-plugin/pull/26