### PR TITLE
Modernization-metadata for blackduck-coverity-on-polaris

### DIFF
--- a/blackduck-coverity-on-polaris/modernization-metadata/2025-07-23T09-04-16.json
+++ b/blackduck-coverity-on-polaris/modernization-metadata/2025-07-23T09-04-16.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "blackduck-coverity-on-polaris",
+  "pluginRepository": "https://github.com/jenkinsci/blackduck-coverity-on-polaris-plugin.git",
+  "pluginVersion": "2.0.1",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.440",
+  "effectiveBaseline": "2.440",
+  "jenkinsVersion": "2.440.3",
+  "migrationName": "Setup the Jenkinsfile",
+  "migrationDescription": "Add a missing Jenkinsfile to the Jenkins plugin.",
+  "tags": [
+    "skip-verification",
+    "chore"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/blackduck-coverity-on-polaris-plugin/pull/8",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 12,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-07-23T09-04-16.json",
+  "path": "metadata-plugin-modernizer/blackduck-coverity-on-polaris/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `blackduck-coverity-on-polaris` at `2025-07-23T09:04:18.424425205Z[UTC]`
PR: https://github.com/jenkinsci/blackduck-coverity-on-polaris-plugin/pull/8