### PR TITLE
Modernization-metadata for cloudbees-enabler

### DIFF
--- a/cloudbees-enabler/modernization-metadata/2025-07-26T10-00-07.json
+++ b/cloudbees-enabler/modernization-metadata/2025-07-26T10-00-07.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "cloudbees-enabler",
+  "pluginRepository": "https://github.com/jenkinsci/cloudbees-enabler-plugin.git",
+  "pluginVersion": "1.43.v5b_7c0c898e84",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.414",
+  "jenkinsVersion": "2.414.1",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/53",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2025-07-26T10-00-07.json",
+  "path": "metadata-plugin-modernizer/cloudbees-enabler/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `cloudbees-enabler` at `2025-07-26T10:00:09.685512658Z[UTC]`
PR: https://github.com/jenkinsci/cloudbees-enabler-plugin/pull/53