### PR TITLE
Modernization-metadata for byte-buddy-api

### DIFF
--- a/byte-buddy-api/modernization-metadata/2025-07-27T09-56-58.json
+++ b/byte-buddy-api/modernization-metadata/2025-07-27T09-56-58.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "byte-buddy-api",
+  "pluginRepository": "https://github.com/jenkinsci/byte-buddy-api-plugin.git",
+  "pluginVersion": "1.17.6-165.vcd5ee8d19447",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/byte-buddy-api-plugin/pull/90",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T09-56-58.json",
+  "path": "metadata-plugin-modernizer/byte-buddy-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `byte-buddy-api` at `2025-07-27T09:57:00.565185011Z[UTC]`
PR: https://github.com/jenkinsci/byte-buddy-api-plugin/pull/90