### PR TITLE
Modernization-metadata for gson-api

### DIFF
--- a/gson-api/modernization-metadata/2025-07-27T10-02-07.json
+++ b/gson-api/modernization-metadata/2025-07-27T10-02-07.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "gson-api",
+  "pluginRepository": "https://github.com/jenkinsci/gson-api-plugin.git",
+  "pluginVersion": "2.13.1-139.v4569c2ef303f",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.1",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/gson-api-plugin/pull/85",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-02-07.json",
+  "path": "metadata-plugin-modernizer/gson-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `gson-api` at `2025-07-27T10:02:10.118990029Z[UTC]`
PR: https://github.com/jenkinsci/gson-api-plugin/pull/85