### PR TITLE
Modernization-metadata for joda-time-api

### DIFF
--- a/joda-time-api/modernization-metadata/2025-07-27T10-03-42.json
+++ b/joda-time-api/modernization-metadata/2025-07-27T10-03-42.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "joda-time-api",
+  "pluginRepository": "https://github.com/jenkinsci/joda-time-api-plugin.git",
+  "pluginVersion": "2.14.0-127.v7d9da_295a_d51",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.1",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/joda-time-api-plugin/pull/79",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-03-42.json",
+  "path": "metadata-plugin-modernizer/joda-time-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `joda-time-api` at `2025-07-27T10:03:45.467126888Z[UTC]`
PR: https://github.com/jenkinsci/joda-time-api-plugin/pull/79