### PR TITLE
Modernization-metadata for jsoup

### DIFF
--- a/jsoup/modernization-metadata/2025-07-27T10-06-49.json
+++ b/jsoup/modernization-metadata/2025-07-27T10-06-49.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "jsoup",
+  "pluginRepository": "https://github.com/jenkinsci/jsoup-plugin.git",
+  "pluginVersion": "1.21.1-52.v96e4041b_60fd",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jsoup-plugin/pull/28",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 1,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-06-49.json",
+  "path": "metadata-plugin-modernizer/jsoup/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jsoup` at `2025-07-27T10:06:52.208847129Z[UTC]`
PR: https://github.com/jenkinsci/jsoup-plugin/pull/28