### PR TITLE
Modernization-metadata for json-path-api

### DIFF
--- a/json-path-api/modernization-metadata/2025-07-27T10-08-21.json
+++ b/json-path-api/modernization-metadata/2025-07-27T10-08-21.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "json-path-api",
+  "pluginRepository": "https://github.com/jenkinsci/json-path-api-plugin.git",
+  "pluginVersion": "2.9.0-148.v22a_7ffe323ce",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.1",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/json-path-api-plugin/pull/93",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-08-21.json",
+  "path": "metadata-plugin-modernizer/json-path-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `json-path-api` at `2025-07-27T10:08:23.615811741Z[UTC]`
PR: https://github.com/jenkinsci/json-path-api-plugin/pull/93