### PR TITLE
Modernization-metadata for jnr-posix-api

### DIFF
--- a/jnr-posix-api/modernization-metadata/2025-07-27T10-10-03.json
+++ b/jnr-posix-api/modernization-metadata/2025-07-27T10-10-03.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "jnr-posix-api",
+  "pluginRepository": "https://github.com/jenkinsci/jnr-posix-api-plugin.git",
+  "pluginVersion": "3.1.20-138.vdb_9db_a_39182f",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.1",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/125",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-10-03.json",
+  "path": "metadata-plugin-modernizer/jnr-posix-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jnr-posix-api` at `2025-07-27T10:10:06.053471632Z[UTC]`
PR: https://github.com/jenkinsci/jnr-posix-api-plugin/pull/125