### PR TITLE
Modernization-metadata for oss-symbols-api

### DIFF
--- a/oss-symbols-api/modernization-metadata/2025-07-27T10-13-15.json
+++ b/oss-symbols-api/modernization-metadata/2025-07-27T10-13-15.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "oss-symbols-api",
+  "pluginRepository": "https://github.com/jenkinsci/oss-symbols-api-plugin.git",
+  "pluginVersion": "388.v1e168e8f0d76",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/214",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 1,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-13-15.json",
+  "path": "metadata-plugin-modernizer/oss-symbols-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `oss-symbols-api` at `2025-07-27T10:13:17.745148327Z[UTC]`
PR: https://github.com/jenkinsci/oss-symbols-api-plugin/pull/214