### PR TITLE
Modernization-metadata for bitbucket-kubernetes-credentials

### DIFF
--- a/bitbucket-kubernetes-credentials/modernization-metadata/2025-07-27T10-20-00.json
+++ b/bitbucket-kubernetes-credentials/modernization-metadata/2025-07-27T10-20-00.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "bitbucket-kubernetes-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin.git",
+  "pluginVersion": "565.v82883f6fdf1b_",
+  "jenkinsBaseline": "2.504",
+  "targetBaseline": "2.504",
+  "effectiveBaseline": "2.504",
+  "jenkinsVersion": "2.504.1",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/301",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 1,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-20-00.json",
+  "path": "metadata-plugin-modernizer/bitbucket-kubernetes-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `bitbucket-kubernetes-credentials` at `2025-07-27T10:20:03.158645516Z[UTC]`
PR: https://github.com/jenkinsci/bitbucket-kubernetes-credentials-plugin/pull/301