### PR TITLE
Modernization-metadata for build-history-metrics-plugin

### DIFF
--- a/build-history-metrics-plugin/modernization-metadata/2025-07-27T10-21-40.json
+++ b/build-history-metrics-plugin/modernization-metadata/2025-07-27T10-21-40.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "build-history-metrics-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/build-history-metrics-plugin.git",
+  "pluginVersion": "141.v371b_7a_d37753",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.1",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/build-history-metrics-plugin/pull/71",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 3,
+  "deletions": 3,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-21-40.json",
+  "path": "metadata-plugin-modernizer/build-history-metrics-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `build-history-metrics-plugin` at `2025-07-27T10:21:43.398752653Z[UTC]`
PR: https://github.com/jenkinsci/build-history-metrics-plugin/pull/71