### PR TITLE
Modernization-metadata for flyway-runner

### DIFF
--- a/flyway-runner/modernization-metadata/2025-07-27T10-32-46.json
+++ b/flyway-runner/modernization-metadata/2025-07-27T10-32-46.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "flyway-runner",
+  "pluginRepository": "https://github.com/jenkinsci/flyway-runner-plugin.git",
+  "pluginVersion": "224.v20b_74326e2c1",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/flyway-runner-plugin/pull/124",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-32-46.json",
+  "path": "metadata-plugin-modernizer/flyway-runner/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `flyway-runner` at `2025-07-27T10:32:49.101812891Z[UTC]`
PR: https://github.com/jenkinsci/flyway-runner-plugin/pull/124