### PR TITLE
Modernization-metadata for jcaptcha-plugin

### DIFF
--- a/jcaptcha-plugin/modernization-metadata/2025-07-27T10-38-19.json
+++ b/jcaptcha-plugin/modernization-metadata/2025-07-27T10-38-19.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "jcaptcha-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/jcaptcha-plugin.git",
+  "pluginVersion": "20.vb_7ecb_3544a_7c",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jcaptcha-plugin/pull/21",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-38-19.json",
+  "path": "metadata-plugin-modernizer/jcaptcha-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jcaptcha-plugin` at `2025-07-27T10:38:21.184872493Z[UTC]`
PR: https://github.com/jenkinsci/jcaptcha-plugin/pull/21