### PR TITLE
Modernization-metadata for jobcacher

### DIFF
--- a/jobcacher/modernization-metadata/2025-07-27T10-40-32.json
+++ b/jobcacher/modernization-metadata/2025-07-27T10-40-32.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "jobcacher",
+  "pluginRepository": "https://github.com/jenkinsci/jobcacher-plugin.git",
+  "pluginVersion": "658.v3a_c3ed19fd14",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jobcacher-plugin/pull/444",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-40-32.json",
+  "path": "metadata-plugin-modernizer/jobcacher/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jobcacher` at `2025-07-27T10:40:35.727927922Z[UTC]`
PR: https://github.com/jenkinsci/jobcacher-plugin/pull/444