### PR TITLE
Modernization-metadata for jobcacher-oras-storage

### DIFF
--- a/jobcacher-oras-storage/modernization-metadata/2025-07-27T10-44-24.json
+++ b/jobcacher-oras-storage/modernization-metadata/2025-07-27T10-44-24.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "jobcacher-oras-storage",
+  "pluginRepository": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin.git",
+  "pluginVersion": "42.v4e213df135f7",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/30",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 1,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-44-24.json",
+  "path": "metadata-plugin-modernizer/jobcacher-oras-storage/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jobcacher-oras-storage` at `2025-07-27T10:44:27.062218774Z[UTC]`
PR: https://github.com/jenkinsci/jobcacher-oras-storage-plugin/pull/30