### PR TITLE
Modernization-metadata for junit-attachments

### DIFF
--- a/junit-attachments/modernization-metadata/2025-07-27T10-46-12.json
+++ b/junit-attachments/modernization-metadata/2025-07-27T10-46-12.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "junit-attachments",
+  "pluginRepository": "https://github.com/jenkinsci/junit-attachments-plugin.git",
+  "pluginVersion": "299.v2e00f511b_538",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/junit-attachments-plugin/pull/179",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-46-12.json",
+  "path": "metadata-plugin-modernizer/junit-attachments/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `junit-attachments` at `2025-07-27T10:46:14.591666822Z[UTC]`
PR: https://github.com/jenkinsci/junit-attachments-plugin/pull/179