### PR TITLE
Modernization-metadata for locale

### DIFF
--- a/locale/modernization-metadata/2025-07-27T10-47-58.json
+++ b/locale/modernization-metadata/2025-07-27T10-47-58.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "locale",
+  "pluginRepository": "https://github.com/jenkinsci/locale-plugin.git",
+  "pluginVersion": "587.v7b_843928a_719",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/locale-plugin/pull/321",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-47-58.json",
+  "path": "metadata-plugin-modernizer/locale/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `locale` at `2025-07-27T10:48:00.900972399Z[UTC]`
PR: https://github.com/jenkinsci/locale-plugin/pull/321