### PR TITLE
Modernization-metadata for next-executions

### DIFF
--- a/next-executions/modernization-metadata/2025-07-27T10-51-37.json
+++ b/next-executions/modernization-metadata/2025-07-27T10-51-37.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "next-executions",
+  "pluginRepository": "https://github.com/jenkinsci/next-executions-plugin.git",
+  "pluginVersion": "424.v631378313e29",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/next-executions-plugin/pull/177",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-51-37.json",
+  "path": "metadata-plugin-modernizer/next-executions/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `next-executions` at `2025-07-27T10:51:40.115862506Z[UTC]`
PR: https://github.com/jenkinsci/next-executions-plugin/pull/177