### PR TITLE
Modernization-metadata for pipeline-cps-http

### DIFF
--- a/pipeline-cps-http/modernization-metadata/2025-07-27T10-59-10.json
+++ b/pipeline-cps-http/modernization-metadata/2025-07-27T10-59-10.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "pipeline-cps-http",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-cps-http-plugin.git",
+  "pluginVersion": "157.vf9a_893b_ed047",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/52",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 2,
+  "changedFiles": 1,
+  "key": "2025-07-27T10-59-10.json",
+  "path": "metadata-plugin-modernizer/pipeline-cps-http/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-cps-http` at `2025-07-27T10:59:13.335166857Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/52