### PR TITLE
Modernization-metadata for pipeline-lib-oras

### DIFF
--- a/pipeline-lib-oras/modernization-metadata/2025-07-27T11-02-56.json
+++ b/pipeline-lib-oras/modernization-metadata/2025-07-27T11-02-56.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "pipeline-lib-oras",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-lib-oras-plugin.git",
+  "pluginVersion": "5.v2b_c0b_458b_8b_2",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Upgrade to the latest recommended core version and ensure the BOM matches the core version",
+  "migrationDescription": "Upgrade to the latest recommended core version and ensure the BOM matches the core version.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToRecommendCoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/12",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 1,
+  "changedFiles": 1,
+  "key": "2025-07-27T11-02-56.json",
+  "path": "metadata-plugin-modernizer/pipeline-lib-oras/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-lib-oras` at `2025-07-27T11:02:59.132285829Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-lib-oras-plugin/pull/12