### PR TITLE
Modernization-metadata for kryptowire

### DIFF
--- a/kryptowire/modernization-metadata/2025-07-29T16-35-40.json
+++ b/kryptowire/modernization-metadata/2025-07-29T16-35-40.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "kryptowire",
+  "pluginRepository": "https://github.com/jenkinsci/kryptowire-plugin.git",
+  "pluginVersion": "0.2",
+  "jenkinsBaseline": "",
+  "targetBaseline": "2.346",
+  "effectiveBaseline": "1.642",
+  "jenkinsVersion": "1.642.3",
+  "migrationName": "Upgrade to latest LTS core version supporting Java 8",
+  "migrationDescription": "Upgrade to latest LTS core version supporting Java 8.",
+  "tags": [
+    "developer"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava8CoreVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/kryptowire-plugin/pull/3",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 26,
+  "deletions": 34,
+  "changedFiles": 6,
+  "key": "2025-07-29T16-35-40.json",
+  "path": "metadata-plugin-modernizer/kryptowire/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `kryptowire` at `2025-07-29T16:35:43.129049854Z[UTC]`
PR: https://github.com/jenkinsci/kryptowire-plugin/pull/3