### PR TITLE
Modernization-metadata for reverse-proxy-auth-plugin

### DIFF
--- a/reverse-proxy-auth-plugin/modernization-metadata/2025-07-31T13-34-59.json
+++ b/reverse-proxy-auth-plugin/modernization-metadata/2025-07-31T13-34-59.json
@@ -1,0 +1,24 @@
+{
+  "pluginName": "reverse-proxy-auth-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/reverse-proxy-auth-plugin.git",
+  "pluginVersion": "238.v82ceca_8417a_6",
+  "jenkinsBaseline": "2.479",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.479",
+  "jenkinsVersion": "2.479.3",
+  "migrationName": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17",
+  "migrationDescription": "Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.",
+  "tags": [
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/reverse-proxy-auth-plugin/pull/194",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 4,
+  "deletions": 25,
+  "changedFiles": 1,
+  "key": "2025-07-31T13-34-59.json",
+  "path": "metadata-plugin-modernizer/reverse-proxy-auth-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `reverse-proxy-auth-plugin` at `2025-07-31T13:35:01.304425367Z[UTC]`
PR: https://github.com/jenkinsci/reverse-proxy-auth-plugin/pull/194