### PR TITLE
Modernization-metadata for commons-math3-api

### DIFF
--- a/commons-math3-api/modernization-metadata/2025-08-09T08-44-34.json
+++ b/commons-math3-api/modernization-metadata/2025-08-09T08-44-34.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "commons-math3-api",
+  "pluginRepository": "https://github.com/jenkinsci/commons-math3-api-plugin.git",
+  "pluginVersion": "3.6.1-70.v4fe220fa_63dd",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/commons-math3-api-plugin/pull/40",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T08-44-34.json",
+  "path": "metadata-plugin-modernizer/commons-math3-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `commons-math3-api` at `2025-08-09T08:44:36.517126339Z[UTC]`
PR: https://github.com/jenkinsci/commons-math3-api-plugin/pull/40