### PR TITLE
Modernization-metadata for gson-api

### DIFF
--- a/gson-api/modernization-metadata/2025-08-09T08-50-08.json
+++ b/gson-api/modernization-metadata/2025-08-09T08-50-08.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "gson-api",
+  "pluginRepository": "https://github.com/jenkinsci/gson-api-plugin.git",
+  "pluginVersion": "2.13.1-153.vb_3d0c48a_a_b_4a_",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/gson-api-plugin/pull/87",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 4,
+  "deletions": 2,
+  "changedFiles": 2,
+  "key": "2025-08-09T08-50-08.json",
+  "path": "metadata-plugin-modernizer/gson-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `gson-api` at `2025-08-09T08:50:11.057258993Z[UTC]`
PR: https://github.com/jenkinsci/gson-api-plugin/pull/87