### PR TITLE
Modernization-metadata for joda-time-api

### DIFF
--- a/joda-time-api/modernization-metadata/2025-08-09T08-52-02.json
+++ b/joda-time-api/modernization-metadata/2025-08-09T08-52-02.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "joda-time-api",
+  "pluginRepository": "https://github.com/jenkinsci/joda-time-api-plugin.git",
+  "pluginVersion": "2.14.0-149.v1c3ce991d1b_9",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/joda-time-api-plugin/pull/80",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 4,
+  "deletions": 2,
+  "changedFiles": 2,
+  "key": "2025-08-09T08-52-02.json",
+  "path": "metadata-plugin-modernizer/joda-time-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `joda-time-api` at `2025-08-09T08:52:05.731782878Z[UTC]`
PR: https://github.com/jenkinsci/joda-time-api-plugin/pull/80