### PR TITLE
Modernization-metadata for jnr-posix-api

### DIFF
--- a/jnr-posix-api/modernization-metadata/2025-08-09T08-59-38.json
+++ b/jnr-posix-api/modernization-metadata/2025-08-09T08-59-38.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "jnr-posix-api",
+  "pluginRepository": "https://github.com/jenkinsci/jnr-posix-api-plugin.git",
+  "pluginVersion": "3.1.20-166.v50a_50932c65b_",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jnr-posix-api-plugin/pull/126",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T08-59-38.json",
+  "path": "metadata-plugin-modernizer/jnr-posix-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jnr-posix-api` at `2025-08-09T08:59:41.062237983Z[UTC]`
PR: https://github.com/jenkinsci/jnr-posix-api-plugin/pull/126