### PR TITLE
Modernization-metadata for mariadb-api

### DIFF
--- a/mariadb-api/modernization-metadata/2025-08-09T09-01-28.json
+++ b/mariadb-api/modernization-metadata/2025-08-09T09-01-28.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "mariadb-api",
+  "pluginRepository": "https://github.com/jenkinsci/mariadb-api-plugin.git",
+  "pluginVersion": "3.5.4-147.vb_6fc046ef86a_",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/mariadb-api-plugin/pull/78",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 4,
+  "deletions": 2,
+  "changedFiles": 2,
+  "key": "2025-08-09T09-01-28.json",
+  "path": "metadata-plugin-modernizer/mariadb-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `mariadb-api` at `2025-08-09T09:01:31.198729293Z[UTC]`
PR: https://github.com/jenkinsci/mariadb-api-plugin/pull/78