### PR TITLE
Modernization-metadata for oss-symbols-api

### DIFF
--- a/oss-symbols-api/modernization-metadata/2025-08-09T09-03-24.json
+++ b/oss-symbols-api/modernization-metadata/2025-08-09T09-03-24.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "oss-symbols-api",
+  "pluginRepository": "https://github.com/jenkinsci/oss-symbols-api-plugin.git",
+  "pluginVersion": "392.v27a_482d90083",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/oss-symbols-api-plugin/pull/217",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 1,
+  "deletions": 0,
+  "changedFiles": 1,
+  "key": "2025-08-09T09-03-24.json",
+  "path": "metadata-plugin-modernizer/oss-symbols-api/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `oss-symbols-api` at `2025-08-09T09:03:27.321998253Z[UTC]`
PR: https://github.com/jenkinsci/oss-symbols-api-plugin/pull/217