### PR TITLE
Modernization-metadata for coverage-badges-extension

### DIFF
--- a/coverage-badges-extension/modernization-metadata/2025-08-09T09-21-03.json
+++ b/coverage-badges-extension/modernization-metadata/2025-08-09T09-21-03.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "coverage-badges-extension",
+  "pluginRepository": "https://github.com/jenkinsci/coverage-badges-extension-plugin.git",
+  "pluginVersion": "179.v6c477ce0c246",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/101",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T09-21-03.json",
+  "path": "metadata-plugin-modernizer/coverage-badges-extension/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `coverage-badges-extension` at `2025-08-09T09:21:05.934915501Z[UTC]`
PR: https://github.com/jenkinsci/coverage-badges-extension-plugin/pull/101