### PR TITLE
Modernization-metadata for flyway-runner

### DIFF
--- a/flyway-runner/modernization-metadata/2025-08-09T09-32-09.json
+++ b/flyway-runner/modernization-metadata/2025-08-09T09-32-09.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "flyway-runner",
+  "pluginRepository": "https://github.com/jenkinsci/flyway-runner-plugin.git",
+  "pluginVersion": "254.vc1b_de1957ddb_",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/flyway-runner-plugin/pull/125",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T09-32-09.json",
+  "path": "metadata-plugin-modernizer/flyway-runner/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `flyway-runner` at `2025-08-09T09:32:12.255216709Z[UTC]`
PR: https://github.com/jenkinsci/flyway-runner-plugin/pull/125