### PR TITLE
Modernization-metadata for jcaptcha-plugin

### DIFF
--- a/jcaptcha-plugin/modernization-metadata/2025-08-09T09-38-53.json
+++ b/jcaptcha-plugin/modernization-metadata/2025-08-09T09-38-53.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "jcaptcha-plugin",
+  "pluginRepository": "https://github.com/jenkinsci/jcaptcha-plugin.git",
+  "pluginVersion": "48.v6c5cca_01a_e10",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/jcaptcha-plugin/pull/23",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T09-38-53.json",
+  "path": "metadata-plugin-modernizer/jcaptcha-plugin/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `jcaptcha-plugin` at `2025-08-09T09:38:56.299068070Z[UTC]`
PR: https://github.com/jenkinsci/jcaptcha-plugin/pull/23