### PR TITLE
Modernization-metadata for next-executions

### DIFF
--- a/next-executions/modernization-metadata/2025-08-09T09-57-26.json
+++ b/next-executions/modernization-metadata/2025-08-09T09-57-26.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "next-executions",
+  "pluginRepository": "https://github.com/jenkinsci/next-executions-plugin.git",
+  "pluginVersion": "446.v57a_a_1b_40702f",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/next-executions-plugin/pull/179",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T09-57-26.json",
+  "path": "metadata-plugin-modernizer/next-executions/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `next-executions` at `2025-08-09T09:57:28.968139473Z[UTC]`
PR: https://github.com/jenkinsci/next-executions-plugin/pull/179