### PR TITLE
Modernization-metadata for openshift-k8s-credentials

### DIFF
--- a/openshift-k8s-credentials/modernization-metadata/2025-08-09T10-01-43.json
+++ b/openshift-k8s-credentials/modernization-metadata/2025-08-09T10-01-43.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "openshift-k8s-credentials",
+  "pluginRepository": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin.git",
+  "pluginVersion": "280.vb_4938766c373",
+  "jenkinsBaseline": "2.504",
+  "targetBaseline": "2.504",
+  "effectiveBaseline": "2.504",
+  "jenkinsVersion": "2.504.2",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/280",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 4,
+  "deletions": 2,
+  "changedFiles": 2,
+  "key": "2025-08-09T10-01-43.json",
+  "path": "metadata-plugin-modernizer/openshift-k8s-credentials/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `openshift-k8s-credentials` at `2025-08-09T10:01:46.033810721Z[UTC]`
PR: https://github.com/jenkinsci/openshift-k8s-credentials-plugin/pull/280