### PR TITLE
Modernization-metadata for pipeline-cps-http

### DIFF
--- a/pipeline-cps-http/modernization-metadata/2025-08-09T10-06-33.json
+++ b/pipeline-cps-http/modernization-metadata/2025-08-09T10-06-33.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "pipeline-cps-http",
+  "pluginRepository": "https://github.com/jenkinsci/pipeline-cps-http-plugin.git",
+  "pluginVersion": "171.v419323d0e4b_c",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/54",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T10-06-33.json",
+  "path": "metadata-plugin-modernizer/pipeline-cps-http/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `pipeline-cps-http` at `2025-08-09T10:06:36.029358015Z[UTC]`
PR: https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/54