### PR TITLE
Modernization-metadata for s3-jobcacher-storage

### DIFF
--- a/s3-jobcacher-storage/modernization-metadata/2025-08-09T10-18-49.json
+++ b/s3-jobcacher-storage/modernization-metadata/2025-08-09T10-18-49.json
@@ -1,0 +1,25 @@
+{
+  "pluginName": "s3-jobcacher-storage",
+  "pluginRepository": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin.git",
+  "pluginVersion": "46.v54b_1e939c810",
+  "jenkinsBaseline": "2.492",
+  "targetBaseline": "2.492",
+  "effectiveBaseline": "2.492",
+  "jenkinsVersion": "2.492.3",
+  "migrationName": "Migrate plugins to Java 25",
+  "migrationDescription": "Migrate plugins to Java 25 LTS.",
+  "tags": [
+    "migration",
+    "dependencies"
+  ],
+  "migrationId": "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
+  "migrationStatus": "success",
+  "pullRequestUrl": "https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/32",
+  "pullRequestStatus": "open",
+  "dryRun": false,
+  "additions": 2,
+  "deletions": 1,
+  "changedFiles": 2,
+  "key": "2025-08-09T10-18-49.json",
+  "path": "metadata-plugin-modernizer/s3-jobcacher-storage/modernization-metadata"
+}


### PR DESCRIPTION
Modernization metadata for `s3-jobcacher-storage` at `2025-08-09T10:18:52.618103580Z[UTC]`
PR: https://github.com/jenkinsci/s3-jobcacher-storage-plugin/pull/32